### PR TITLE
Make the pyinstaller work on Linux too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /logs/*
 .idea/*
 __pycache__
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,22 +1,44 @@
 # SMBX2 Tileset Importer
 
-_Note: This software is currently in Beta. If you experience any errors or bugs, please report them 
+_Note: This software is currently in Beta. If you experience any errors or bugs, please report them
 [here](https://github.com/Sambo3975/SMBX2-Tileset-Creator/issues/new?assignees=&labels=&template=bug_report.md&title=)._
 
 ## About
 
-This program streamlines the creation of tilesets in SMBX2 by automating the most tedious parts of the process:
+This program streamlines the creation of tilesets for SMBX2 (and also limited support for TheXTech) by automating the most tedious parts of the process:
 - Cutting the image with all your tiles into individual block-*.png images.
-- Finding IDs for all the images
-- Creating the .tileset.ini file in PGE.
+- Finding IDs for all the images.
+- Creating the `.tileset.ini` file for the Moondust Editor (former PGE Editor).
 
-This program was designed for Windows and may not work right on other platforms. I figured this would be fine since
-SMBX doesn't run on anything but Windows (or Wine) anyway. If you want to try to use it on another platform or test 
-unreleased features, feel free to build it yourself.
+This program was originally designed for Windows, however it also can work on Linux if you will install all necessary
+python3 packages. I figured this would be fine since SMBX2 doesn't run on anything but Windows (or Wine) anyway.
+If you want to try to use it on another platform or test unreleased features, feel free to build it yourself.
+
+This program also has limited support for [TheXTech project](https://github.com/Wohlstand/TheXTech/wiki), the enhanced
+cross-platform port of the SMBX 1.3. It has the support for PNG sprites and has the full native support by the standalone
+Moondust Editor (out of SMBX2) include the direct level testing, however, it doesn't support any config files to
+customize settings for blocks and BGOs yet and keeps using the same itemset as SMBX 1.3 had even reserved blocks
+and BGO entries.
+
 
 ## Installation
 
+### On Windows
 Get the current release [here](https://github.com/Sambo3975/SMBX2-Tileset-Creator/releases).
+
+### On Linux
+This program can work on Linux-based operating system. If the public release build won't work for any reason, you
+are able to run the project directly. The Python 3.8 and higher is recommended, it may work on older
+version but no guarantee it will work.
+
+If you have the Debian-based distribution, you need to install the next dependencies from the package manager until you
+will get the program work:
+```bash
+sudo apt install tix-dev python3-tk python3-regex python3-pil
+```
+
+Then, clone this repository into any convenient directory and try to run the `main.py` script to start the program.
+
 
 ## How to Use
 
@@ -41,9 +63,9 @@ The software allows you to interact with tiles in the following ways.
 
 #### Creating a New Tile
 
-To create a new tile, left-click and drag over the area of the image you want the tile to occupy. The edges of your 
-selection will automatically snap to the grid. When you release the mouse button, a new tile will be created. You can 
-then edit that tile's settings in the right panel. Note that tiles may not overlap. If your selection overlaps with an 
+To create a new tile, left-click and drag over the area of the image you want the tile to occupy. The edges of your
+selection will automatically snap to the grid. When you release the mouse button, a new tile will be created. You can
+then edit that tile's settings in the right panel. Note that tiles may not overlap. If your selection overlaps with an
 existing tile, a new tile will not be created.
 
 #### Selecting a Tile
@@ -72,12 +94,12 @@ caused by hand-editing this file, as they will be ignored._
 
 ### Exporting the Tileset
 
-To export the tileset, go to File->Export or press Ctrl + E. This will create a directory with the same name as your 
+To export the tileset, go to File->Export or press Ctrl + E. This will create a directory with the same name as your
 tileset image and fill it with several .png and .txt files, as well as up to two .tileset.ini files if you have chosen
-to create PGE tilesets. Copy and paste the contents of this folder to the folder of the level you wish to use the tiles
+to create Moondust Editor tilesets. Copy and paste the contents of this folder to the folder of the level you wish to use the tiles
 in.
 
-This process will also assign IDs to all unassigned blocks and lock these IDs in place. This ensures that all existing 
+This process will also assign IDs to all unassigned blocks and lock these IDs in place. This ensures that all existing
 tiles will keep the same ID in future exports, even if tiles are added or deleted from the tileset. If, for whatever
 reason, you want to re-assign the automatically-generated IDs, you can clear the assigned IDs from File->Clear
 Auto-Assigned IDs. This will not clear IDs that you manually assigned to individual tiles.
@@ -93,7 +115,7 @@ will be aborted. The different warning messages and resolutions to them are desc
 
 ![Imgur](https://imgur.com/QDMuLMd.png)
 
-`n invalid tileset settings` -- This indicates that `n` of the settings for the tileset have bad values. Check the left 
+`n invalid tileset settings` -- This indicates that `n` of the settings for the tileset have bad values. Check the left
 panel and correct any settings that are marked with warning icons (⚠), then try again.
 
 `n tiles with invalid settings` -- This indicates that `n` tiles are not configured properly. To resolve this, check all
@@ -102,14 +124,14 @@ tiles that are marked with warning icons (⚠) and correct any settings that are
 ![Imgur](https://imgur.com/kLdf1g3.png)
 
 This indicates that you have not allocated enough IDs for all tiles that are set to have their IDs automatically
-assigned. To resolve this, either add more IDs to the indicated ID pool on the left panel, or specify IDs for more 
+assigned. To resolve this, either add more IDs to the indicated ID pool on the left panel, or specify IDs for more
 tiles (using the Tile ID field on the right panel), then try again.
 
-#### Note about PGE tilesets
+#### Note about Editor tilesets
 
-The software will try to arrange the tiles in PGE tilesets as closely to their arrangement in the image as possible.
+The software will try to arrange the tiles in Moondust Editor tilesets as closely to their arrangement in the image as possible.
 However, this is not always possible if tiles are of differing sizes. You may wish to make some minor adjustments to
-the tileset in PGE after you export.
+the tileset in Moondust Editor after you export.
 
 ## Known Issues
 
@@ -127,21 +149,21 @@ The following features are planned for future releases. You can request a new fe
 
 ### Tileset Configurations
 
-**Name** -- The name the tileset will have in PGE. This will also affect the name of the
+**Name** -- The name the tileset will have in Moondust Editor. This will also affect the name of the
 `.tileset.ini` file itself. If not specified, the tileset will be named 'Imported (Block/BGO) Tileset'
 
 ### Grid Configurations
 
-**Padding** -- Adds gaps between grid squares (tileset creators commonly place a 1 or 2 px gap between 
+**Padding** -- Adds gaps between grid squares (tileset creators commonly place a 1 or 2 px gap between
 tiles)
 
 **Offsets** -- Horizontal and vertical offsets for the grid
 
 ### Tile Configurations
 
-**Name** -- The name the tile will have in PGE. The tile's name will be something like 'Imported Tile' if not defined.
+**Name** -- The name the tile will have in Moondust Editor. The tile's name will be something like 'Imported Tile' if not defined.
 
-**Description** -- The description the tile will have in PGE. This will be empty if not defined.
+**Description** -- The description the tile will have in Moondust Editor. This will be empty if not defined.
 
 ### Placement Modes
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ _Note: This software is currently in Beta. If you experience any errors or bugs,
 
 ## About
 
-This program streamlines the creation of tilesets for SMBX2 (and also limited support for TheXTech) by automating the most tedious parts of the process:
+This program streamlines the creation of tilesets for SMBX2 and TheXTech by automating the most tedious parts of the process:
 - Cutting the image with all your tiles into individual block-*.png images.
 - Finding IDs for all the images.
 - Creating the `.tileset.ini` file for the Moondust Editor (former PGE Editor).

--- a/main.spec
+++ b/main.spec
@@ -1,11 +1,14 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import pathlib
+import sys
 
 block_cipher = None
 
+path = pathlib.Path().absolute();
 
 a = Analysis(['main.py'],
-             pathex=['C:\\Users\\sambo\\PycharmProjects\\TilesetCreator'],
+             pathex=[path],
              binaries=[],
              hiddenimports=[],
              hookspath=[],
@@ -15,7 +18,11 @@ a = Analysis(['main.py'],
              win_private_assemblies=False,
              cipher=block_cipher,
              noarchive=False)
-a.datas += [('data/icon.ico', 'data/icon.ico', 'DATA')]
+
+if sys.platform == "win32":
+    a.datas += [('data/icon.ico', 'data/icon.ico', 'DATA')]
+else:
+    a.datas += [('data/icon_32.png', 'data/icon_32.png', 'DATA')]
 a.datas += [('data/tile_error.png', 'data/tile_error.png', 'DATA')]
 
 pyz = PYZ(a.pure, a.zipped_data,
@@ -34,4 +41,4 @@ exe = EXE(pyz,
           upx=True,
           upx_exclude=[],
           runtime_tmpdir=None,
-          console=False )
+          console=False)


### PR DESCRIPTION
It's a minor fix that allows using the `pyinstaller` to generate the native Linux runtime binary.

Also, ReadMe was been clarified and updated.